### PR TITLE
Update CORS to use config; add production settings

### DIFF
--- a/src/BeloteEngine.Api/Program.cs
+++ b/src/BeloteEngine.Api/Program.cs
@@ -78,7 +78,10 @@ builder.Services.AddCors(options =>
         }
         else
         {
-            policy.WithOrigins("https://yourdomain.com", "https://www.yourdomain.com")
+            var allowedOrigins = builder.Configuration["AllowedOrigins"]
+                ?? throw new InvalidOperationException("AllowedOrigins is not configured.");
+
+            policy.WithOrigins(allowedOrigins)
                   .AllowAnyHeader()
                   .AllowAnyMethod()
                   .AllowCredentials();

--- a/src/BeloteEngine.Api/appsettings.Production.json
+++ b/src/BeloteEngine.Api/appsettings.Production.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "your-railway-app.railway.app",
+  "AllowedOrigins": "https://your-online-belote.vercel.app"
+}


### PR DESCRIPTION
Refactor CORS to read AllowedOrigins from configuration instead of hardcoding values. Add appsettings.Production.json with logging, AllowedHosts, and AllowedOrigins for environment-specific setup.