### PR TITLE
fix github actions

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  GCP_REGION: europe-west1 # change to your preferred region
+  GCP_REGION: europe-west8
   SERVICE_NAME: beloteengine
 
 jobs:


### PR DESCRIPTION
This pull request updates the configuration for the CI workflow to use a different Google Cloud Platform region.

Configuration update:

* [`.github/workflows/dotnet-ci.yml`](diffhunk://#diff-bd6c1bcfcaa13ae3662b9fbb7e13fa55a46715d4ba656f6d663717d309101b6dL10-R10): Changed the `GCP_REGION` environment variable from `europe-west1` to `europe-west8` to deploy services in a new region.